### PR TITLE
Version 1.0.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.phasmidsoftware"
 
 name := "Number"
 
-version := "1.0.10"
+version := "1.0.11-SNAPSHOT"
 
 scalaVersion := "2.13.6"
 

--- a/src/main/scala/com/phasmidsoftware/number/core/Expression.scala
+++ b/src/main/scala/com/phasmidsoftware/number/core/Expression.scala
@@ -346,7 +346,7 @@ object AtomicExpression {
     case Literal(x) => Some(x)
     case c: Constant => Some(c.evaluate)
     case f: Field => Some(f)
-    case g: GeneralNumber => Some(g)
+//    case g: GeneralNumber => Some(g)
     case _ => None
   }
 }
@@ -666,7 +666,7 @@ case class BiFunction(a: Expression, b: Expression, f: ExpressionBiFunction) ext
     * TODO refactor this method to remove all parameters since they are simply copies of the values in scope.
     *
     * @param f the function.
-    * @param a first operand.
+    * @param a first operand (currently ignored)
     * @param b second operand.
     * @return true if the result of the f(a,b) is exact.
     */

--- a/src/main/scala/com/phasmidsoftware/number/core/GeneralNumber.scala
+++ b/src/main/scala/com/phasmidsoftware/number/core/GeneralNumber.scala
@@ -2,6 +2,7 @@ package com.phasmidsoftware.number.core
 
 import com.phasmidsoftware.number.core.FP._
 import com.phasmidsoftware.number.core.Number.{negate, prepareWithSpecialize}
+
 import java.util.NoSuchElementException
 import scala.annotation.tailrec
 import scala.util._
@@ -482,7 +483,7 @@ abstract class GeneralNumber(val value: Value, val factor: Factor, val fuzz: Opt
   /**
     * An optional Double that corresponds to the value of this Number (but ignoring the factor).
     */
-  def maybeDouble: Option[Double] = optionMap(value)(_.toDouble, x => optionMap(x)(_.toDouble, identity))
+  def maybeDouble: Option[Double] = Value.maybeDouble(value)
 
   /**
     * An optional Int that corresponds to the value of this Number (but ignoring the factor).

--- a/src/main/scala/com/phasmidsoftware/number/core/Number.scala
+++ b/src/main/scala/com/phasmidsoftware/number/core/Number.scala
@@ -6,6 +6,7 @@ import com.phasmidsoftware.number.core.Rational.toInts
 import com.phasmidsoftware.number.core.Render.renderValue
 import com.phasmidsoftware.number.core.Value.{fromDouble, fromInt, fromRational}
 import com.phasmidsoftware.number.parse.NumberParser
+
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.math.BigInt
@@ -1084,7 +1085,8 @@ object Number {
 
   def exp(x: Number): Number = x.scale(Scalar).make(E)
 
-  private def scaleDouble(x: Double, fThis: Factor, fResult: Factor) = x * fThis.value / fResult.value
+  // TODO use the method in Value.
+  def scaleDouble(x: Double, fThis: Factor, fResult: Factor): Double = x * fThis.value / fResult.value
 
   /**
     * This method returns a Number equivalent to x but with the value in an explicit factor-dependent range.


### PR DESCRIPTION
Reworking Values and Factors to allow for other logarithmic scales

build.sbt:
* updated to V1.0.11-SNAPSHOT;
* updated scalaTest to 3.2.9;
* updated scalacheck to 1.15.4;
* updated logback-classic to 1.2.5.

Value:
* added maybeDouble and scaleDouble methods to Value object;
* added convert method to Factor trait;
* renamed (more or less) NonScalarFactor as Logarithmic;
* introduced new PureNumber trait;